### PR TITLE
Fixed a bug in ipe/websocket.go 

### DIFF
--- a/ipe/websocket.go
+++ b/ipe/websocket.go
@@ -79,10 +79,9 @@ func onMessage(conn *websocket.Conn, w http.ResponseWriter, r *http.Request, ses
 
 		if err != nil {
 			log.Errorf("%+v", err)
-			switch err {
-			case io.EOF:
+			if _, ok := err.(*websocket.CloseError); ok {
 				onClose(sessionID, app)
-			default:
+			} else {
 				emitWSError(newGenericReconnectImmediatelyError(), conn)
 			}
 			break


### PR DESCRIPTION
TotalConnections were growing infinitely; connection was not closed when a channel listener client refreshed or simply closed the browser tab.