### PR TITLE
Do not overuse defer unnecessarily

### DIFF
--- a/ipe/db.go
+++ b/ipe/db.go
@@ -30,10 +30,8 @@ func newMemdb() *memdb {
 
 func (db *memdb) AddApp(a *app) error {
 	db.Lock()
-	defer db.Unlock()
-
 	db.Apps = append(db.Apps, a)
-
+	db.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
It is a bit better IMO to not use defer for mutex Lock/Unlock because we should release the lock as soon as possible, not just at the very end of the function via defer. Program code is better readable this way, too. (I know, there are cases when using defer is better, this is just not such a case.)