### PR TITLE
Fixed a bug in ipe/websocket.go

### DIFF
--- a/ipe/websocket.go
+++ b/ipe/websocket.go
@@ -79,10 +79,11 @@ func onMessage(conn *websocket.Conn, w http.ResponseWriter, r *http.Request, ses
 
 		if err != nil {
 			log.Errorf("%+v", err)
-			switch err {
-			case io.EOF:
+			if err == io.EOF {
 				onClose(sessionID, app)
-			default:
+			} else if _, ok := err.(*websocket.CloseError); ok {
+				onClose(sessionID, app)
+			} else {
 				emitWSError(newGenericReconnectImmediatelyError(), conn)
 			}
 			break


### PR DESCRIPTION
TotalConnections were growing infinitely before this. Connection was not closed when a channel listener refreshed the browser tab or simply closed the browser tab. Note: this is a revised patch