### PR TITLE
Use maps instead of for loops to search in memdb for apps

### DIFF
--- a/ipe/db.go
+++ b/ipe/db.go
@@ -18,7 +18,7 @@ type db interface {
 	AddApp(*app) error
 }
 
-// memdb is a in memory implementation of db interface
+// memdb is an in memory implementation of db interface
 type memdb struct {
 	IdMutex     sync.Mutex
 	KeyMutex    sync.Mutex
@@ -41,16 +41,15 @@ func (db *memdb) AddApp(a *app) error {
 	db.KeyMutex.Lock()
 	db.AppsByKey[a.Key] = a
 	db.KeyMutex.Unlock()
-
 	return nil
 }
 
 // GetAppByAppID returns an App with by appID
 func (db *memdb) GetAppByAppID(appID string) (*app, error) {
 	db.IdMutex.Lock()
-	a, exists := db.AppsByAppID[appID]
+	a, ok := db.AppsByAppID[appID]
 	db.IdMutex.Unlock()
-	if exists {
+	if ok {
 		return a, nil
 	}
 	return nil, errors.New("App not found")
@@ -59,9 +58,9 @@ func (db *memdb) GetAppByAppID(appID string) (*app, error) {
 // GetAppByKey returns an App with by key
 func (db *memdb) GetAppByKey(key string) (*app, error) {
 	db.KeyMutex.Lock()
-	a, exists := db.AppsByKey[key]
+	a, ok := db.AppsByKey[key]
 	db.KeyMutex.Unlock()
-	if exists {
+	if ok {
 		return a, nil
 	}
 	return nil, errors.New("App not found")

--- a/ipe/db.go
+++ b/ipe/db.go
@@ -27,7 +27,10 @@ type memdb struct {
 }
 
 func newMemdb() *memdb {
-	return &memdb{}
+	return &memdb{
+		AppsByAppID: make(map[string]*app),
+		AppsByKey:   make(map[string]*app),
+	}
 }
 
 func (db *memdb) AddApp(a *app) error {


### PR DESCRIPTION
Sorry about the previous broken patch. :( This one should work.

Note: Since we only store pointers in each map, there won't be excessive memory usage. However, the lookup will be much faster because a map key lookup must be much faster than using a for loop.

Also, please notice that the mutex lock must be used when you look up an app, too. Not just when you add a new item to the slice (or map). If you do not use locking around the lookup, then you cannot concurrently add and lookup apps, or if you do so then you are risking a runtime panic. (Because the slice might get moved/reallocated when adding a new entry to it.)