### PR TITLE
Add dockerfile and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:alpine as builder
+RUN mkdir /build 
+ADD . /build/
+WORKDIR /build 
+RUN apk add git gcc musl-dev
+RUN go build -o ipe ./cmd
+FROM alpine
+USER root
+RUN  mkdir -p /config
+RUN adduser -S -D -H -h /app appuser
+COPY ./entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+USER appuser
+WORKDIR /app
+COPY --from=builder /build/ipe /app/
+COPY --from=builder /build/config-example.yml /app/config-example.yml
+VOLUME /config
+CMD ["/bin/sh", "/app/entrypoint.sh"]
+EXPOSE 4343
+EXPOSE 8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "$(ls -A /config)" ]; then
+   cp /app/config-example.yml /config/config.yml
+fi
+
+/app/ipe --config=/config/config.yml


### PR DESCRIPTION
I've created a Dockerfile and entrypoint script which should be good for production. The binary gets built in a build container separate from the resulting image. 

Users can create a volume at /config to store the config.yml. The entrypoint script will check if the directory is empty when the container gets brought up, and if so, it will copy the config-example.yml into the /config/config.yml, which is the path that gets passed in as the config path.

If this is sufficient, it should solve https://github.com/dimiro1/ipe/issues/45

As @bmartel had mentioned, viper could be used to handle the config files, but that could probably be handled as a new issue